### PR TITLE
CLOUD-850: Post Box Info to Warehouse; self-identification of boxes

### DIFF
--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.js
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.js
@@ -10,6 +10,7 @@ frappe.ui.form.on("Server Box", {
 			frm.add_custom_button("Get Update Zip", function () {
 				get_zip_content(frm, "get_update_zip");
 			});
+			frm.set_df_property("server_box_version", "read_only", 1);
 		}
 	},
 });

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.json
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.json
@@ -52,8 +52,7 @@
    "fieldtype": "Link",
    "label": "Server Box Version",
    "options": "Server Box Version",
-   "reqd": 1,
-   "set_only_once": 1
+   "reqd": 1
   },
   {
    "fieldname": "instance_name",
@@ -95,7 +94,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-23 19:19:02.311228",
+ "modified": "2025-06-24 09:47:57.834253",
  "modified_by": "Administrator",
  "module": "Service Warehouse",
  "name": "Server Box",

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.json
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.json
@@ -95,7 +95,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-05 10:37:40.467720",
+ "modified": "2025-06-23 19:19:02.311228",
  "modified_by": "Administrator",
  "module": "Service Warehouse",
  "name": "Server Box",
@@ -119,5 +119,6 @@
  ],
  "sort_field": "modified",
  "sort_order": "DESC",
- "states": []
+ "states": [],
+ "title_field": "box_name"
 }

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.py
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.py
@@ -63,6 +63,7 @@ class ServerBox(Document):
             self.doctype, self.name, "instance_name", instance_name.lower()
         )
         frappe.db.commit()
+        self.reload()
 
 
 def get_zip_file_content(server_box_id, field_name):

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.py
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.py
@@ -59,10 +59,8 @@ class ServerBox(Document):
         tenant_name = tenant[0].name
         box_type = self.box_type.replace(" Box", "")
         instance_name = f"{tenant_name}-{box_type}-{self.name}"
-        frappe.db.set_value(
-            self.doctype, self.name, "instance_name", instance_name.lower()
-        )
-        frappe.db.commit()
+        self.instance_name = instance_name.lower()
+        self.save()
         self.reload()
 
 

--- a/service_warehouse/service_warehouse/services/server_box_service.py
+++ b/service_warehouse/service_warehouse/services/server_box_service.py
@@ -42,7 +42,7 @@ def update_server_box_info_data(*args, **kwargs):
                 f"Server Box with instance name {instance_name} does not exist."
             )
         frappe.db.set_value(
-            doc.doctype, doc.name, "box_information", json.dumps(box_info_data)
+            doc.doctype, doc.name, "box_information", json.dumps(box_info_data, indent=2)
         )
         frappe.db.commit()
         return {"message": "Server box info data updated successfully."}


### PR DESCRIPTION
🐞 Bugfix
- Server Box name is now editable after creation
- Server Box instance name displays immediately without requiring a page refresh