### PR TITLE
CLOUD-886: Server Box Management Improvments on Warehouse

### DIFF
--- a/service_warehouse/fixtures/role.json
+++ b/service_warehouse/fixtures/role.json
@@ -1,0 +1,15 @@
+[
+ {
+  "desk_access": 1,
+  "disabled": 0,
+  "docstatus": 0,
+  "doctype": "Role",
+  "home_page": null,
+  "is_custom": 0,
+  "modified": "2025-07-18 10:48:31.065949",
+  "name": "Host",
+  "restrict_to_domain": null,
+  "role_name": "Host",
+  "two_factor_auth": 0
+ }
+]

--- a/service_warehouse/hooks.py
+++ b/service_warehouse/hooks.py
@@ -17,6 +17,7 @@ fixtures = [
                                           ["extension_code", "not like", "%Test%"],
                                           ["extension_code", "not like", "%TEST%"]
                                         ]},
+  {"dt": "Role", "filters": [["name", "in", ["Host"]]]},
 ]
 
 

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.js
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.js
@@ -4,14 +4,18 @@
 frappe.ui.form.on("Server Box", {
 	refresh(frm) {
 		if (!frm.is_new()) {
-			frm.add_custom_button("Get Installation Zip", function () {
-				get_zip_content(frm, "get_installation_zip");
-			});
 			frm.add_custom_button("Get Update Zip", function () {
 				get_zip_content(frm, "get_update_zip");
 			});
 			frm.set_df_property("server_box_version", "read_only", 1);
 		}
+	},
+	onload: function (frm) {
+		frm.set_query("server_box_version", () => {
+			return {
+				query: "service_warehouse.service_warehouse.doctype.server_box.server_box.custom_link_query",
+			};
+		});
 	},
 });
 

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.js
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.js
@@ -7,7 +7,14 @@ frappe.ui.form.on("Server Box", {
 			frm.add_custom_button("Get Update Zip", function () {
 				get_zip_content(frm, "get_update_zip");
 			});
-			frm.set_df_property("server_box_version", "read_only", 1);
+			change_fields_read_only_property(frm, 1);
+			if (frappe.user_roles.includes("Host"))
+				frm.add_custom_button("Get Installation Zip", function () {
+					get_zip_content(frm, "get_installation_zip");
+				});
+			frm.set_df_property("tenant", "read_only", 0);
+		} else {
+			change_fields_read_only_property(frm, 0);
 		}
 	},
 	onload: function (frm) {
@@ -44,4 +51,11 @@ function get_zip_content(frm, command) {
 			}
 		},
 	});
+}
+
+function change_fields_read_only_property(frm, read_only) {
+	frm.set_df_property("box_type", "read_only", read_only);
+	frm.set_df_property("server_box_version", "read_only", read_only);
+	frm.set_df_property("box_url", "read_only", read_only);
+	frm.set_df_property("tenant", "read_only", read_only);
 }

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.json
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.json
@@ -28,9 +28,9 @@
   {
    "fieldname": "tenant",
    "fieldtype": "Link",
-   "hidden": 1,
    "label": "Tenant",
-   "options": "Tenant"
+   "options": "Tenant",
+   "read_only": 1
   },
   {
    "fieldname": "box_type",
@@ -74,7 +74,7 @@
   {
    "fieldname": "column_break_9bsr",
    "fieldtype": "Column Break",
-   "label": "Advenved Info"
+   "label": "Advanced Info"
   },
   {
    "fieldname": "notes",
@@ -94,7 +94,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-24 09:47:57.834253",
+ "modified": "2025-07-23 11:40:55.542732",
  "modified_by": "Administrator",
  "module": "Service Warehouse",
  "name": "Server Box",
@@ -102,15 +102,20 @@
  "owner": "Administrator",
  "permissions": [
   {
+   "if_owner": 1,
+   "read": 1,
+   "role": "System Manager",
+   "write": 1
+  },
+  {
    "create": 1,
    "delete": 1,
    "email": 1,
    "export": 1,
-   "if_owner": 1,
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "System Manager",
+   "role": "Host",
    "select": 1,
    "share": 1,
    "write": 1

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.py
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.py
@@ -31,13 +31,11 @@ class ServerBox(Document):
 
     def validate(self):
         if self.box_type == "Service Box":
-            user = frappe.session.user
-            user_data = frappe.get_doc("User", user).as_dict()
             tenant_client_box = frappe.get_all(
                 "Server Box",
                 filters={
                     "box_type": "Client Box",
-                    "owner": user_data.get("name"),
+                    "tenant": self.tenant
                 },
                 fields=["name"],
             )
@@ -51,16 +49,12 @@ class ServerBox(Document):
             frappe.throw("Box URL must start with 'http://' or 'https://'.")
 
     def after_insert(self):
-        user = frappe.session.user
-        user_data = frappe.get_doc("User", user).as_dict()
-        tenant = frappe.get_all("Tenant", filters={"user": user_data.get("email")})
-        if not tenant or len(tenant) == 0:
-            frappe.throw("Tenant not found for the user.")
-        tenant_name = tenant[0].name
+        tenant = frappe.get_doc("Tenant", self.tenant)
         box_type = self.box_type.replace(" Box", "")
-        instance_name = f"{tenant_name}-{box_type}-{self.name}"
+        instance_name = f"{self.tenant}-{box_type}-{self.name}"
         self.instance_name = instance_name.lower()
-        self.save()
+        frappe.db.set_value(self.doctype, self.name, "owner", tenant.user, update_modified=False)
+        frappe.db.commit()
         self.reload()
 
 
@@ -86,18 +80,6 @@ def get_zip_file_content(server_box_id, field_name):
     return {"filename": file_doc.file_name, "content_base64": encoded, "success": True}
 
 
-def getNextBoxVersion(server_box_id):
-    server_box = frappe.get_doc("Server Box", server_box_id)
-    if not server_box:
-        frappe.throw(f"Server Box with ID {server_box_id} does not exist.")
-    server_box_versions = frappe.get_all("Server Box Version")
-    server_box_versions.sort(key=lambda x: x.name, reverse=True)
-    for version in server_box_versions:
-        if int(version.name) > int(server_box.server_box_version):
-            server_box_version = frappe.get_doc("Server Box Version", version)
-            return server_box_version
-    return None
-
 
 @frappe.whitelist()
 def get_installation_zip(*args, **kwargs):
@@ -112,27 +94,7 @@ def get_installation_zip(*args, **kwargs):
 def get_update_zip(*args, **kwargs):
     try:
         server_box_id = kwargs.get("server_box_id")
-        new_version = getNextBoxVersion(server_box_id)
-        if new_version is not None:
-            server_box = frappe.get_doc("Server Box", server_box_id)
-            if not server_box:
-                frappe.throw(f"Server Box with ID {server_box_id} does not exist.")
-            if not new_version.update_zip:
-                frappe.throw(
-                    f"No update zip file found for version: {new_version.name}"
-                )
-            frappe.db.set_value(
-                "Server Box", server_box.name, "server_box_version", new_version.name
-            )
-            frappe.db.commit()
-            return get_zip_file_content(server_box_id, "update_zip")
-
-        frappe.msgprint(
-            msg="You are using latest box version.",
-            title="Box Update Message!",
-            raise_exception=False,
-            indicator="yellow",
-        )
+        return get_zip_file_content(server_box_id, "update_zip")
     except Exception as e:
         frappe.throw(f"Error while getting update zip: {str(e)}")
 

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.py
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.py
@@ -135,3 +135,13 @@ def get_update_zip(*args, **kwargs):
         )
     except Exception as e:
         frappe.throw(f"Error while getting update zip: {str(e)}")
+
+@frappe.whitelist()
+def custom_link_query(doctype, txt, searchfield, start, page_len, filters):
+    return frappe.db.sql("""
+        SELECT `name`, `version_name`
+        FROM `tabServer Box Version`
+        WHERE `version_name` LIKE %s
+        ORDER BY `version_name`
+        LIMIT %s OFFSET %s
+    """, ("%%%s%%" % txt, page_len, start))

--- a/service_warehouse/service_warehouse/doctype/server_box_version/server_box_version.json
+++ b/service_warehouse/service_warehouse/doctype/server_box_version/server_box_version.json
@@ -17,7 +17,8 @@
    "fieldtype": "Data",
    "in_list_view": 1,
    "label": "Version Name",
-   "reqd": 1
+   "reqd": 1,
+   "unique": 1
   },
   {
    "fieldname": "update_zip",
@@ -45,7 +46,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-07-18 10:52:03.140701",
+ "modified": "2025-07-29 10:28:37.882977",
  "modified_by": "Administrator",
  "module": "Service Warehouse",
  "name": "Server Box Version",

--- a/service_warehouse/service_warehouse/doctype/server_box_version/server_box_version.json
+++ b/service_warehouse/service_warehouse/doctype/server_box_version/server_box_version.json
@@ -45,7 +45,7 @@
  ],
  "index_web_pages_for_search": 1,
  "links": [],
- "modified": "2025-06-04 20:24:36.138678",
+ "modified": "2025-07-18 10:52:03.140701",
  "modified_by": "Administrator",
  "module": "Service Warehouse",
  "name": "Server Box Version",
@@ -60,9 +60,13 @@
    "print": 1,
    "read": 1,
    "report": 1,
-   "role": "System Manager",
+   "role": "Host",
    "share": 1,
    "write": 1
+  },
+  {
+   "role": "System Manager",
+   "select": 1
   }
  ],
  "show_title_field_in_link": 1,

--- a/service_warehouse/service_warehouse/services/server_box_service.py
+++ b/service_warehouse/service_warehouse/services/server_box_service.py
@@ -32,10 +32,9 @@ def update_server_box_info_data(*args, **kwargs):
         if not box_info_data:
             frappe.throw("Box information data is required.")
         instance_name = kwargs.get("instance_name")
+        server_box_version = kwargs.get("server_box_version")
         if not instance_name:
             frappe.throw("Instance name is required.")
-        user = frappe.session.user
-        user_data = frappe.get_doc("User", user).as_dict()
         doc = frappe.get_doc("Server Box", {"instance_name": instance_name})
         if not doc:
             frappe.throw(
@@ -43,6 +42,9 @@ def update_server_box_info_data(*args, **kwargs):
             )
         frappe.db.set_value(
             doc.doctype, doc.name, "box_information", json.dumps(box_info_data, indent=2)
+        )
+        frappe.db.set_value(
+            doc.doctype, doc.name, "server_box_version", server_box_version
         )
         frappe.db.commit()
         return {"message": "Server box info data updated successfully."}

--- a/service_warehouse/service_warehouse/services/server_box_service.py
+++ b/service_warehouse/service_warehouse/services/server_box_service.py
@@ -32,7 +32,7 @@ def update_server_box_info_data(*args, **kwargs):
         if not box_info_data:
             frappe.throw("Box information data is required.")
         instance_name = kwargs.get("instance_name")
-        server_box_version = kwargs.get("server_box_version")
+        # server_box_version = kwargs.get("server_box_version")
         if not instance_name:
             frappe.throw("Instance name is required.")
         doc = frappe.get_doc("Server Box", {"instance_name": instance_name})
@@ -43,9 +43,9 @@ def update_server_box_info_data(*args, **kwargs):
         frappe.db.set_value(
             doc.doctype, doc.name, "box_information", json.dumps(box_info_data, indent=2)
         )
-        frappe.db.set_value(
-            doc.doctype, doc.name, "server_box_version", server_box_version
-        )
+        # frappe.db.set_value(
+        #     doc.doctype, doc.name, "server_box_version", server_box_version
+        # )
         frappe.db.commit()
         return {"message": "Server box info data updated successfully."}
     except Exception as e:


### PR DESCRIPTION
✨ Added
- Enforced permissions and visibility rules for Server Boxes:
  - Host users can view and manage all boxes
  - Regular users can view and edit only their own boxes
  - Only Host users can create new boxes

🔄 Changed
- Server Box Versions are now retrieved from the box itself, no longer managed by Frappe (warehouse)
- Restricted access to Install ZIP files:
  - Only Host users can download install zips
  - All other users can only access update zips

🐞 Bugfix
- Fixed issue where mc_version was showing as null under Advanced Info
  - Now properly collected during server_box_info gathering