### PR TITLE
CLOUD-910: Bugfix for Getting Update Zip in Server Box Page

### DIFF
--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.js
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.js
@@ -32,7 +32,7 @@ function get_zip_content(frm, command) {
 		method: `service_warehouse.service_warehouse.doctype.server_box.server_box.${command}`,
 		args: { server_box_id: frm.doc.name },
 		callback: (r) => {
-			if (r.message) {
+			if (r.message && r.message.status) {
 				const base64Data = r.message.content_base64;
 				const byteCharacters = atob(base64Data);
 				const byteNumbers = new Array(byteCharacters.length);
@@ -49,6 +49,8 @@ function get_zip_content(frm, command) {
 				link.click();
 				document.body.removeChild(link);
 				frm.reload_doc();
+			} else {
+				frappe.msgprint(r.message.message || "Failed to get the zip file.");
 			}
 		},
 	});

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.py
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.py
@@ -65,15 +65,6 @@ class ServerBox(Document):
 
 
 def get_zip_file_content(server_box_id, field_name):
-    def get_next_id(current_id):
-        result = frappe.db.get_value(
-            "Server Box Version",
-            filters={"name": [">", current_id]},
-            fieldname="name",
-            order_by="name ASC",
-        )
-        return result  # Returns the next higher ID or None if not found
-
     if not server_box_id:
         frappe.throw("Server Box ID is required to get the zip file.")
     server_box = frappe.get_doc("Server Box", server_box_id)
@@ -81,35 +72,33 @@ def get_zip_file_content(server_box_id, field_name):
         frappe.throw(f"Server Box with ID {server_box_id} does not exist.")
     if not server_box.server_box_version:
         frappe.throw("Server Box Version is not set for this Server Box.")
-    if field_name == "install_zip":
-        server_box_version = frappe.get_doc(
-            "Server Box Version", server_box.server_box_version
-        )
-    elif field_name == "update_zip":
-        next_server_box_version_id = get_next_id(server_box.server_box_version)
-        if not next_server_box_version_id:
-            frappe.msgprint("You are using latest Server Box Version. No Update!")
-            return None
-        server_box_version = frappe.get_doc(
-            "Server Box Version", next_server_box_version_id
-        )
+
+    server_box_version = frappe.get_doc(
+        "Server Box Version", server_box.server_box_version
+    )
 
     file_url = getattr(server_box_version, field_name, None)
     if not file_url:
-        frappe.throw(
-            f"No file attached in field '{field_name}' for version: {server_box_version.name}"
-        )
+        if field_name == "update_file":
+            return {
+                "status": False,
+                "message": "You are using latest Server Box Version. No Update!",
+            }
+        else:
+            frappe.throw(
+                f"No file attached in field '{field_name}' for version: {server_box_version.name}"
+            )
     file_doc = frappe.get_doc("File", {"file_url": file_url})
     with open(file_doc.get_full_path(), "rb") as f:
         encoded = base64.b64encode(f.read()).decode()
-    return {"filename": file_doc.file_name, "content_base64": encoded, "success": True}
+    return {"filename": file_doc.file_name, "content_base64": encoded, "status": True}
 
 
 @frappe.whitelist()
 def get_installation_zip(*args, **kwargs):
     try:
         server_box_id = kwargs.get("server_box_id")
-        return get_zip_file_content(server_box_id, "install_zip")
+        return get_zip_file_content(server_box_id, "installation_file")
     except Exception as e:
         frappe.throw(f"Error while getting installation zip: {str(e)}")
 
@@ -118,7 +107,7 @@ def get_installation_zip(*args, **kwargs):
 def get_update_zip(*args, **kwargs):
     try:
         server_box_id = kwargs.get("server_box_id")
-        return get_zip_file_content(server_box_id, "update_zip")
+        return get_zip_file_content(server_box_id, "update_file")
     except Exception as e:
         frappe.throw(f"Error while getting update zip: {str(e)}")
 

--- a/service_warehouse/service_warehouse/doctype/server_box/server_box.py
+++ b/service_warehouse/service_warehouse/doctype/server_box/server_box.py
@@ -33,10 +33,7 @@ class ServerBox(Document):
         if self.box_type == "Service Box":
             tenant_client_box = frappe.get_all(
                 "Server Box",
-                filters={
-                    "box_type": "Client Box",
-                    "tenant": self.tenant
-                },
+                filters={"box_type": "Client Box", "tenant": self.tenant},
                 fields=["name"],
             )
             if len(tenant_client_box) == 0:
@@ -53,13 +50,30 @@ class ServerBox(Document):
         box_type = self.box_type.replace(" Box", "")
         instance_name = f"{self.tenant}-{box_type}-{self.name}"
         instance_name = instance_name.lower()
-        frappe.db.set_value(self.doctype, self.name, "owner", tenant.user, update_modified=False)
-        frappe.db.set_value(self.doctype, self.name, "instance_name", instance_name, update_modified=False)
+        frappe.db.set_value(
+            self.doctype, self.name, "owner", tenant.user, update_modified=False
+        )
+        frappe.db.set_value(
+            self.doctype,
+            self.name,
+            "instance_name",
+            instance_name,
+            update_modified=False,
+        )
         frappe.db.commit()
         self.reload()
 
 
 def get_zip_file_content(server_box_id, field_name):
+    def get_next_id(current_id):
+        result = frappe.db.get_value(
+            "Server Box Version",
+            filters={"name": [">", current_id]},
+            fieldname="name",
+            order_by="name ASC",
+        )
+        return result  # Returns the next higher ID or None if not found
+
     if not server_box_id:
         frappe.throw("Server Box ID is required to get the zip file.")
     server_box = frappe.get_doc("Server Box", server_box_id)
@@ -67,9 +81,19 @@ def get_zip_file_content(server_box_id, field_name):
         frappe.throw(f"Server Box with ID {server_box_id} does not exist.")
     if not server_box.server_box_version:
         frappe.throw("Server Box Version is not set for this Server Box.")
-    server_box_version = frappe.get_doc(
-        "Server Box Version", server_box.server_box_version
-    )
+    if field_name == "install_zip":
+        server_box_version = frappe.get_doc(
+            "Server Box Version", server_box.server_box_version
+        )
+    elif field_name == "update_zip":
+        next_server_box_version_id = get_next_id(server_box.server_box_version)
+        if not next_server_box_version_id:
+            frappe.msgprint("You are using latest Server Box Version. No Update!")
+            return None
+        server_box_version = frappe.get_doc(
+            "Server Box Version", next_server_box_version_id
+        )
+
     file_url = getattr(server_box_version, field_name, None)
     if not file_url:
         frappe.throw(
@@ -79,7 +103,6 @@ def get_zip_file_content(server_box_id, field_name):
     with open(file_doc.get_full_path(), "rb") as f:
         encoded = base64.b64encode(f.read()).decode()
     return {"filename": file_doc.file_name, "content_base64": encoded, "success": True}
-
 
 
 @frappe.whitelist()
@@ -99,12 +122,16 @@ def get_update_zip(*args, **kwargs):
     except Exception as e:
         frappe.throw(f"Error while getting update zip: {str(e)}")
 
+
 @frappe.whitelist()
 def custom_link_query(doctype, txt, searchfield, start, page_len, filters):
-    return frappe.db.sql("""
+    return frappe.db.sql(
+        """
         SELECT `name`, `version_name`
         FROM `tabServer Box Version`
         WHERE `version_name` LIKE %s
         ORDER BY `version_name`
         LIMIT %s OFFSET %s
-    """, ("%%%s%%" % txt, page_len, start))
+    """,
+        ("%%%s%%" % txt, page_len, start),
+    )

--- a/service_warehouse/service_warehouse/doctype/server_box_version/server_box_version.json
+++ b/service_warehouse/service_warehouse/doctype/server_box_version/server_box_version.json
@@ -8,8 +8,8 @@
   "section_break_8cl9",
   "version_name",
   "section_break_gl76",
-  "install_zip",
-  "update_zip"
+  "installation_file",
+  "update_file"
  ],
  "fields": [
   {
@@ -21,19 +21,6 @@
    "unique": 1
   },
   {
-   "fieldname": "update_zip",
-   "fieldtype": "Attach",
-   "label": "Update Zip",
-   "reqd": 1
-  },
-  {
-   "fieldname": "install_zip",
-   "fieldtype": "Attach",
-   "in_list_view": 1,
-   "label": "Install Zip",
-   "reqd": 1
-  },
-  {
    "fieldname": "section_break_8cl9",
    "fieldtype": "Section Break",
    "label": "Version Information"
@@ -41,12 +28,29 @@
   {
    "fieldname": "section_break_gl76",
    "fieldtype": "Section Break",
-   "label": "Zip Files"
+   "label": "Setup Files"
+  },
+  {
+   "fieldname": "installation_file",
+   "fieldtype": "Attach",
+   "in_list_view": 1,
+   "label": "Installation File",
+   "reqd": 1
+  },
+  {
+   "fieldname": "update_file",
+   "fieldtype": "Attach",
+   "label": "Update File"
   }
  ],
  "index_web_pages_for_search": 1,
- "links": [],
- "modified": "2025-07-29 10:28:37.882977",
+ "links": [
+  {
+   "link_doctype": "Server Box",
+   "link_fieldname": "server_box_version"
+  }
+ ],
+ "modified": "2025-09-09 01:23:25.553296",
  "modified_by": "Administrator",
  "module": "Service Warehouse",
  "name": "Server Box Version",

--- a/service_warehouse/service_warehouse/doctype/server_box_version/server_box_version.py
+++ b/service_warehouse/service_warehouse/doctype/server_box_version/server_box_version.py
@@ -14,9 +14,9 @@ class ServerBoxVersion(Document):
     if TYPE_CHECKING:
         from frappe.types import DF
 
-        install_zip: DF.Attach
+        installation_file: DF.Attach
         name: DF.Int | None
-        update_zip: DF.Attach
+        update_file: DF.Attach | None
         version_name: DF.Data
     # end: auto-generated types
     pass

--- a/service_warehouse/service_warehouse/services/server_box_service.py
+++ b/service_warehouse/service_warehouse/services/server_box_service.py
@@ -40,12 +40,12 @@ def update_server_box_info_data(*args, **kwargs):
             frappe.throw(
                 f"Server Box with instance name {instance_name} does not exist."
             )
-        frappe.db.set_value(
-            doc.doctype, doc.name, "box_information", json.dumps(box_info_data, indent=2)
+        doc.box_information = json.dumps(box_info_data, indent=2)
+        server_box_version_doc = frappe.get_doc(
+            "Server Box Version", {"version_name": server_box_version}
         )
-        frappe.db.set_value(
-            doc.doctype, doc.name, "server_box_version", server_box_version
-        )
+        doc.server_box_version = server_box_version_doc
+        doc.save()
         frappe.db.commit()
         return {"message": "Server box info data updated successfully."}
     except Exception as e:


### PR DESCRIPTION
✨ Added  
-  Displaying Server Boxes as connection in the Server Box Version document

🔄 Changed  
- Updated behavior of the Update Zip button:  
  - Previously checked the next version (e.g., 3.5.0) update files field for a box on 3.4.0  
  - Now correctly checks the current version (3.4.0) update files field  
- Made the Update Zip field optional instead of mandatory when creating a Server Box version  
- Renamed Zip Files tab to Setup Files  
- Renamed fields:  
  - Install Zip → Installation File  
  - Update Zip → Update File  

🐞 Bugfix  
- Fixed incorrect route redirection when clicking the Server Box Version link field in Server Box  
